### PR TITLE
Caching system/ repositories added

### DIFF
--- a/weather_application/lib/app.dart
+++ b/weather_application/lib/app.dart
@@ -1,5 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:hive/hive.dart';
 import 'package:weather_application/clients/weather_client.dart';
+import 'package:weather_application/models/forecast_model.dart';
+import 'package:weather_application/repositories/hive_repository.dart';
+import 'package:weather_application/repositories/weather_repository.dart';
+import 'models/weather_model.dart';
 
 class MyApp extends StatelessWidget {
   @override
@@ -7,24 +12,75 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       home: Scaffold(
-          body: FutureBuilder(
-        future: WeatherClient().fetchForecastWeather('London', 'metric'),
-        builder: (BuildContext context, AsyncSnapshot snapshot) {
-          if (snapshot.hasData && snapshot.data != null) {
-            return Container(
-              width: 200,
               height: 200,
-              color: Colors.greenAccent,
-            );
-          } else {
-            return Container(
-              width: 200,
-              height: 200,
-              color: Colors.redAccent,
-            );
-          }
-        },
-      )),
+        body: Column(
+          children: [
+            Expanded(
+              flex: 1,
+              child: FutureBuilder(
+                future: WeatherRepository(
+                  client: WeatherClient(),
+                  box: HiveRepository(
+                    Hive.box<Forecast>(forecastBox),
+                  ),
+                ).getForecastWeather(forecastBox, 'London', 'metric'),
+                builder: (BuildContext context, AsyncSnapshot<Forecast> snapshot) {
+                  if (snapshot.hasData && snapshot.data != null) {
+                    return Container(
+                      width: 200,
+                      height: 200,
+                      color: Colors.purpleAccent,
+                      child: Center(
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          mainAxisAlignment: MainAxisAlignment.spaceAround,
+                          children: [
+                            Text(snapshot.data.forecast[0].description),
+                            Text(snapshot.data.forecast.length.toString()),
+                          ],
+                        ),
+                      ),
+                    );
+                  } else {
+                    return Container(
+                      width: 200,
+                      height: 200,
+                      color: Colors.redAccent,
+                    );
+                  }
+                },
+              ),
+            ),
+            Expanded(
+              flex: 1,
+              child: FutureBuilder(
+                future: WeatherRepository(
+                  client: WeatherClient(),
+                  box: HiveRepository(
+                    Hive.box<Weather>(currentBox),
+                  ),
+                ).getCurrentWeather(currentBox, 'London', 'metric'),
+                builder: (BuildContext context, AsyncSnapshot<Weather> snapshot) {
+                  if (snapshot.hasData && snapshot.data != null) {
+                    return Container(
+                      width: 200,
+                      height: 200,
+                      color: Colors.greenAccent,
+                      child: Center(child: Text(snapshot.data.name)),
+                    );
+                  } else {
+                    return Container(
+                      width: 200,
+                      height: 200,
+                      color: Colors.redAccent,
+                    );
+                  }
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/weather_application/lib/clients/weather_client.dart
+++ b/weather_application/lib/clients/weather_client.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:weather_application/models/forecast_model.dart';
 import 'package:weather_application/models/weather_model.dart';
 
 class WeatherClient {
@@ -10,8 +11,11 @@ class WeatherClient {
     this._dio = Dio();
   }
 
-  Future<Weather> fetchCurrentWeather(String cityName, String units) async {
-    final String url = '${_baseUrl}weather?q=$cityName&appid=$_apiKey&units=$units';
+  Future<Weather> fetchCurrentWeather({
+    String cityName = 'London',
+    String unit = 'metric',
+  }) async {
+    final String url = '${_baseUrl}weather?q=$cityName&appid=$_apiKey&units=$unit';
     try {
       final response = await _dio.get(url);
       final weather = Weather.fromJson(response.data);
@@ -21,15 +25,14 @@ class WeatherClient {
     }
   }
 
-  Future<List<Weather>> fetchForecastWeather(String cityName, String unit) async {
+  Future<Forecast> fetchForecastWeather({
+    String cityName = 'London',
+    String unit = 'metric',
+  }) async {
     final String url = "${_baseUrl}forecast?q=$cityName&appid=$_apiKey&units=$unit";
     try {
       final response = await _dio.get(url);
-      final List<Weather> forecast = [];
-      for (var weatherItem in response.data['list']) {
-        forecast.add(Weather.fromJson(weatherItem));
-      }
-      return forecast;
+      return Forecast.fromJson(response.data);
     } on DioError catch (e) {
       throw e;
     }

--- a/weather_application/lib/interfaces/i_repository.dart
+++ b/weather_application/lib/interfaces/i_repository.dart
@@ -1,0 +1,4 @@
+abstract class IRepository<T> {
+  Future<dynamic> get(dynamic id, [String cityName, String unit]);
+  Future<void> put(dynamic id, T object);
+}

--- a/weather_application/lib/main.dart
+++ b/weather_application/lib/main.dart
@@ -1,13 +1,27 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:hive/hive.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:weather_application/models/forecast_model.dart';
+import 'package:weather_application/repositories/weather_repository.dart';
 import 'app.dart';
+import 'models/weather_model.dart';
 
 void _registerDeviceOrientations() {
   SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
 }
 
-void main() {
+void _registerTypeAdapters() {
+  Hive.registerAdapter(WeatherAdapter());
+  Hive.registerAdapter(ForecastAdapter());
+}
+
+void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   _registerDeviceOrientations();
+  await Hive.initFlutter();
+  _registerTypeAdapters();
+  await Hive.openBox<Weather>(currentBox);
+  await Hive.openBox<Forecast>(forecastBox);
   runApp(MyApp());
 }

--- a/weather_application/lib/models/forecast_model.dart
+++ b/weather_application/lib/models/forecast_model.dart
@@ -1,0 +1,23 @@
+import 'dart:convert';
+
+import 'package:hive/hive.dart';
+import 'package:weather_application/models/weather_model.dart';
+part 'forecast_model.g.dart';
+
+@HiveType(typeId: 1)
+class Forecast {
+  @HiveField(0)
+  List<Weather> forecast;
+
+  Forecast({this.forecast});
+
+  factory Forecast.fromJson(Map<String, dynamic> json) {
+    return Forecast(
+      forecast: List<Weather>.from(
+        json['list'].map(
+          (weather) => Weather.fromJson(weather),
+        ),
+      ),
+    );
+  }
+}

--- a/weather_application/lib/models/forecast_model.g.dart
+++ b/weather_application/lib/models/forecast_model.g.dart
@@ -1,0 +1,41 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'forecast_model.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class ForecastAdapter extends TypeAdapter<Forecast> {
+  @override
+  final int typeId = 1;
+
+  @override
+  Forecast read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return Forecast(
+      forecast: (fields[0] as List)?.cast<Weather>(),
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, Forecast obj) {
+    writer
+      ..writeByte(1)
+      ..writeByte(0)
+      ..write(obj.forecast);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ForecastAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/weather_application/lib/models/weather_model.dart
+++ b/weather_application/lib/models/weather_model.dart
@@ -1,3 +1,7 @@
+import 'package:hive/hive.dart';
+part 'weather_model.g.dart';
+
+@HiveType(typeId: 0)
 class Weather {
   Weather({
     this.id,
@@ -18,21 +22,37 @@ class Weather {
     this.dtTxt,
   });
 
+  @HiveField(0)
   int id;
+  @HiveField(1)
   String main;
+  @HiveField(2)
   String description;
+  @HiveField(3)
   String icon;
+  @HiveField(4)
   double temp;
+  @HiveField(5)
   double feelsLike;
+  @HiveField(6)
   double tempMin;
+  @HiveField(7)
   double tempMax;
+  @HiveField(8)
   int humidity;
+  @HiveField(9)
   double windSpeed;
+  @HiveField(10)
   String country;
+  @HiveField(11)
   int sunrise;
+  @HiveField(12)
   int sunset;
+  @HiveField(13)
   int dt;
+  @HiveField(14)
   String name;
+  @HiveField(15)
   String dtTxt;
 
   factory Weather.fromJson(Map<String, dynamic> json) {
@@ -41,12 +61,12 @@ class Weather {
       main: json["weather"][0]["main"],
       description: json["weather"][0]["description"],
       icon: json["weather"][0]["icon"],
-      temp: json["main"]["temp"],
+      temp: json["main"]["temp"].toDouble(),
       feelsLike: json["main"]["feels_like"].toDouble(),
       tempMin: json["main"]["temp_min"].toDouble(),
       tempMax: json["main"]["temp_max"].toDouble(),
       humidity: json["main"]["humidity"],
-      windSpeed: json["wind"]["speed"],
+      windSpeed: json["wind"]["speed"].toDouble(),
       country: json["sys"]["country"],
       sunrise: json["sys"]["sunrise"],
       sunset: json["sys"]["sunset"],

--- a/weather_application/lib/models/weather_model.g.dart
+++ b/weather_application/lib/models/weather_model.g.dart
@@ -1,0 +1,86 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'weather_model.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class WeatherAdapter extends TypeAdapter<Weather> {
+  @override
+  final int typeId = 0;
+
+  @override
+  Weather read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return Weather(
+      id: fields[0] as int,
+      main: fields[1] as String,
+      description: fields[2] as String,
+      icon: fields[3] as String,
+      temp: fields[4] as double,
+      feelsLike: fields[5] as double,
+      tempMin: fields[6] as double,
+      tempMax: fields[7] as double,
+      humidity: fields[8] as int,
+      windSpeed: fields[9] as double,
+      country: fields[10] as String,
+      sunrise: fields[11] as int,
+      sunset: fields[12] as int,
+      dt: fields[13] as int,
+      name: fields[14] as String,
+      dtTxt: fields[15] as String,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, Weather obj) {
+    writer
+      ..writeByte(16)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.main)
+      ..writeByte(2)
+      ..write(obj.description)
+      ..writeByte(3)
+      ..write(obj.icon)
+      ..writeByte(4)
+      ..write(obj.temp)
+      ..writeByte(5)
+      ..write(obj.feelsLike)
+      ..writeByte(6)
+      ..write(obj.tempMin)
+      ..writeByte(7)
+      ..write(obj.tempMax)
+      ..writeByte(8)
+      ..write(obj.humidity)
+      ..writeByte(9)
+      ..write(obj.windSpeed)
+      ..writeByte(10)
+      ..write(obj.country)
+      ..writeByte(11)
+      ..write(obj.sunrise)
+      ..writeByte(12)
+      ..write(obj.sunset)
+      ..writeByte(13)
+      ..write(obj.dt)
+      ..writeByte(14)
+      ..write(obj.name)
+      ..writeByte(15)
+      ..write(obj.dtTxt);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WeatherAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/weather_application/lib/repositories/hive_repository.dart
+++ b/weather_application/lib/repositories/hive_repository.dart
@@ -1,0 +1,32 @@
+import 'package:hive/hive.dart';
+import 'package:weather_application/interfaces/i_repository.dart';
+
+class HiveRepository<T> implements IRepository<T> {
+  final Box _box;
+
+  HiveRepository(this._box) : assert(_box != null);
+
+  @override
+  Future<dynamic> get(id, [String cityName, String unit]) async {
+    if (this.isBoxOpen && this._box.isNotEmpty) {
+      try {
+        return this._box.get(id);
+      } catch (e) {
+        return e;
+      }
+    }
+
+    return null;
+  }
+
+  @override
+  Future<void> put(id, T object) async {
+    if (this.isBoxOpen) {
+      await this._box.put(id, object);
+    }
+
+    return;
+  }
+
+  bool get isBoxOpen => (this._box?.isOpen ?? true);
+}

--- a/weather_application/lib/repositories/weather_repository.dart
+++ b/weather_application/lib/repositories/weather_repository.dart
@@ -1,0 +1,50 @@
+import 'package:hive/hive.dart';
+import 'package:weather_application/clients/weather_client.dart';
+import 'package:weather_application/interfaces/i_repository.dart';
+import 'package:weather_application/models/forecast_model.dart';
+import 'package:weather_application/models/weather_model.dart';
+
+const String currentBox = 'currentBox';
+const String forecastBox = 'forecastBox';
+
+class WeatherRepository {
+  final WeatherClient client;
+  final IRepository<dynamic> box;
+
+  WeatherRepository({
+    this.box,
+    this.client,
+  }) : assert(client != null);
+
+  Future<Weather> getCurrentWeather(id, [String cityName, String unit]) async {
+    final localWeather = await this.box.get(id);
+    if (localWeather != null) {
+      print("localWeather");
+      return localWeather;
+    } else {
+      final remoteWeather = await this.client.fetchCurrentWeather(
+            cityName: cityName,
+            unit: unit,
+          );
+      await this.box.put(id, remoteWeather);
+      print("remoteWeather");
+      return remoteWeather;
+    }
+  }
+
+  Future<Forecast> getForecastWeather(id, [String cityName, String unit]) async {
+    final localForecast = await box.get(id);
+    if (localForecast != null) {
+      print("localForecast");
+      return localForecast;
+    } else {
+      final remoteForecast = await this.client.fetchForecastWeather(
+            cityName: cityName,
+            unit: unit,
+          );
+      await this.box.put(id, remoteForecast);
+      print("remoteForecast");
+      return remoteForecast;
+    }
+  }
+}

--- a/weather_application/pubspec.yaml
+++ b/weather_application/pubspec.yaml
@@ -25,6 +25,9 @@ dependencies:
     sdk: flutter
   provider: ^4.3.3
   dio: ^3.0.10
+  hive: ^2.0.0
+  hive_flutter: ^1.0.0
+  path_provider: ^2.0.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -33,8 +36,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  hive_generator: ^0.8.2
-  build_runner: ^1.11.0
+  hive_generator: ^1.0.0
+  build_runner: ^1.11.5
   
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
Implemented the weather repository for retrieving the various weather objects from the server/cache.

Created a generic hive repository class that is responsible for getting and saving any object T in cache against a unique key.

Hive requires type adapters to cache objects directly so they have also been generated.

Currently as it stands if there is a Weather/Forecast in cache it will use the cached version. This is not completely correct as we need to check connectivity status to decide whether to fetch from the local storage/ server.