### PR TITLE
Implemented weather bloc

### DIFF
--- a/weather_application/lib/app.dart
+++ b/weather_application/lib/app.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:hive/hive.dart';
+import 'package:weather_application/blocs/weather/weather_bloc.dart';
 import 'package:weather_application/clients/weather_client.dart';
-import 'package:weather_application/models/forecast_model.dart';
 import 'package:weather_application/repositories/hive_repository.dart';
 import 'package:weather_application/repositories/weather_repository.dart';
 import 'models/weather_model.dart';
@@ -9,76 +10,37 @@ import 'models/weather_model.dart';
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      home: Scaffold(
-              height: 200,
-        body: Column(
-          children: [
-            Expanded(
-              flex: 1,
-              child: FutureBuilder(
-                future: WeatherRepository(
-                  client: WeatherClient(),
-                  box: HiveRepository(
-                    Hive.box<Forecast>(forecastBox),
-                  ),
-                ).getForecastWeather(forecastBox, 'London', 'metric'),
-                builder: (BuildContext context, AsyncSnapshot<Forecast> snapshot) {
-                  if (snapshot.hasData && snapshot.data != null) {
-                    return Container(
-                      width: 200,
-                      height: 200,
-                      color: Colors.purpleAccent,
-                      child: Center(
-                        child: Row(
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          mainAxisAlignment: MainAxisAlignment.spaceAround,
-                          children: [
-                            Text(snapshot.data.forecast[0].description),
-                            Text(snapshot.data.forecast.length.toString()),
-                          ],
-                        ),
-                      ),
-                    );
-                  } else {
-                    return Container(
-                      width: 200,
-                      height: 200,
-                      color: Colors.redAccent,
-                    );
-                  }
-                },
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<WeatherBloc>(
+          create: (BuildContext context) => WeatherBloc(
+            repository: WeatherRepository(
+              client: WeatherClient(),
+              box: HiveRepository(
+                Hive.box<Weather>(currentBox),
               ),
             ),
-            Expanded(
-              flex: 1,
-              child: FutureBuilder(
-                future: WeatherRepository(
-                  client: WeatherClient(),
-                  box: HiveRepository(
-                    Hive.box<Weather>(currentBox),
-                  ),
-                ).getCurrentWeather(currentBox, 'London', 'metric'),
-                builder: (BuildContext context, AsyncSnapshot<Weather> snapshot) {
-                  if (snapshot.hasData && snapshot.data != null) {
-                    return Container(
-                      width: 200,
-                      height: 200,
-                      color: Colors.greenAccent,
-                      child: Center(child: Text(snapshot.data.name)),
-                    );
-                  } else {
-                    return Container(
-                      width: 200,
-                      height: 200,
-                      color: Colors.redAccent,
-                    );
-                  }
-                },
-              ),
-            ),
-          ],
+          )..add(WeatherFetchedEvent(city: 'London', id: currentBox, unit: 'metric')),
+        )
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        home: Scaffold(
+          body: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              BlocBuilder<WeatherBloc, WeatherState>(builder: (context, state) {
+                if (state is WeatherLoadSuccess) {
+                  return Text(state.weather.country);
+                }
+                if (state is WeatherLoadFailure) {
+                  return Center(child: Text('Unable to fetch Weather'));
+                } else {
+                  return CircularProgressIndicator();
+                }
+              }),
+            ],
+          ),
         ),
       ),
     );

--- a/weather_application/lib/blocs/weather/weather_bloc.dart
+++ b/weather_application/lib/blocs/weather/weather_bloc.dart
@@ -1,0 +1,39 @@
+import 'dart:async';
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:meta/meta.dart';
+import 'package:weather_application/models/weather_model.dart';
+import 'package:weather_application/repositories/weather_repository.dart';
+
+part 'weather_event.dart';
+part 'weather_state.dart';
+
+class WeatherBloc extends Bloc<WeatherEvent, WeatherState> {
+  final WeatherRepository repository;
+
+  WeatherBloc({@required this.repository})
+      : assert(repository != null),
+        super(WeatherInitial());
+
+  @override
+  Stream<WeatherState> mapEventToState(
+    WeatherEvent event,
+  ) async* {
+    if (event is WeatherFetchedEvent) {
+      yield* _mapWeatherFetchedToState(event);
+    }
+  }
+
+  Stream<WeatherState> _mapWeatherFetchedToState(WeatherFetchedEvent event) async* {
+    try {
+      final Weather weather = await repository.getCurrentWeather(
+        event.id,
+        event.city,
+        event.unit,
+      );
+      yield WeatherLoadSuccess(weather: weather);
+    } catch (e) {
+      yield WeatherLoadFailure();
+    }
+  }
+}

--- a/weather_application/lib/blocs/weather/weather_event.dart
+++ b/weather_application/lib/blocs/weather/weather_event.dart
@@ -1,0 +1,21 @@
+part of 'weather_bloc.dart';
+
+@immutable
+abstract class WeatherEvent extends Equatable {
+  const WeatherEvent();
+}
+
+class WeatherFetchedEvent extends WeatherEvent {
+  final String id;
+  final String city;
+  final String unit;
+
+  const WeatherFetchedEvent({
+    this.id,
+    this.city,
+    this.unit,
+  });
+
+  @override
+  List<Object> get props => [id, city, unit];
+}

--- a/weather_application/lib/blocs/weather/weather_state.dart
+++ b/weather_application/lib/blocs/weather/weather_state.dart
@@ -1,0 +1,20 @@
+part of 'weather_bloc.dart';
+
+@immutable
+abstract class WeatherState extends Equatable {
+  @override
+  List<Object> get props => [];
+}
+
+class WeatherInitial extends WeatherState {}
+
+class WeatherLoadSuccess extends WeatherState {
+  final Weather weather;
+
+  WeatherLoadSuccess({@required this.weather});
+
+  @override
+  List<Object> get props => [weather];
+}
+
+class WeatherLoadFailure extends WeatherState {}

--- a/weather_application/lib/main.dart
+++ b/weather_application/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:bloc/bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:hive/hive.dart';
@@ -6,6 +7,14 @@ import 'package:weather_application/models/forecast_model.dart';
 import 'package:weather_application/repositories/weather_repository.dart';
 import 'app.dart';
 import 'models/weather_model.dart';
+
+class SimpleBlocDelegate extends BlocObserver {
+  @override
+  void onTransition(Bloc bloc, Transition transition) {
+    super.onTransition(bloc, transition);
+    print(transition);
+  }
+}
 
 void _registerDeviceOrientations() {
   SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
@@ -23,5 +32,6 @@ void main() async {
   _registerTypeAdapters();
   await Hive.openBox<Weather>(currentBox);
   await Hive.openBox<Forecast>(forecastBox);
+  Bloc.observer = SimpleBlocDelegate();
   runApp(MyApp());
 }

--- a/weather_application/lib/models/weather_model.dart
+++ b/weather_application/lib/models/weather_model.dart
@@ -1,26 +1,28 @@
 import 'package:hive/hive.dart';
+
+import 'forecast_model.dart';
 part 'weather_model.g.dart';
 
 @HiveType(typeId: 0)
 class Weather {
-  Weather({
-    this.id,
-    this.main,
-    this.description,
-    this.icon,
-    this.temp,
-    this.feelsLike,
-    this.tempMin,
-    this.tempMax,
-    this.humidity,
-    this.windSpeed,
-    this.country,
-    this.sunrise,
-    this.sunset,
-    this.dt,
-    this.name,
-    this.dtTxt,
-  });
+  Weather(
+      {this.id,
+      this.main,
+      this.description,
+      this.icon,
+      this.temp,
+      this.feelsLike,
+      this.tempMin,
+      this.tempMax,
+      this.humidity,
+      this.windSpeed,
+      this.country,
+      this.sunrise,
+      this.sunset,
+      this.dt,
+      this.name,
+      this.dtTxt,
+      this.forecast});
 
   @HiveField(0)
   int id;
@@ -54,6 +56,8 @@ class Weather {
   String name;
   @HiveField(15)
   String dtTxt;
+  @HiveField(16)
+  Forecast forecast;
 
   factory Weather.fromJson(Map<String, dynamic> json) {
     return Weather(

--- a/weather_application/lib/models/weather_model.g.dart
+++ b/weather_application/lib/models/weather_model.g.dart
@@ -33,13 +33,14 @@ class WeatherAdapter extends TypeAdapter<Weather> {
       dt: fields[13] as int,
       name: fields[14] as String,
       dtTxt: fields[15] as String,
+      forecast: fields[16] as Forecast,
     );
   }
 
   @override
   void write(BinaryWriter writer, Weather obj) {
     writer
-      ..writeByte(16)
+      ..writeByte(17)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -71,7 +72,9 @@ class WeatherAdapter extends TypeAdapter<Weather> {
       ..writeByte(14)
       ..write(obj.name)
       ..writeByte(15)
-      ..write(obj.dtTxt);
+      ..write(obj.dtTxt)
+      ..writeByte(16)
+      ..write(obj.forecast);
   }
 
   @override

--- a/weather_application/lib/repositories/weather_repository.dart
+++ b/weather_application/lib/repositories/weather_repository.dart
@@ -1,7 +1,5 @@
-import 'package:hive/hive.dart';
 import 'package:weather_application/clients/weather_client.dart';
 import 'package:weather_application/interfaces/i_repository.dart';
-import 'package:weather_application/models/forecast_model.dart';
 import 'package:weather_application/models/weather_model.dart';
 
 const String currentBox = 'currentBox';
@@ -22,29 +20,11 @@ class WeatherRepository {
       print("localWeather");
       return localWeather;
     } else {
-      final remoteWeather = await this.client.fetchCurrentWeather(
-            cityName: cityName,
-            unit: unit,
-          );
+      var remoteWeather = await this.client.fetchCurrentWeather(cityName: cityName, unit: unit);
+      remoteWeather.forecast = await this.client.fetchForecastWeather(cityName: cityName, unit: unit);
       await this.box.put(id, remoteWeather);
       print("remoteWeather");
       return remoteWeather;
-    }
-  }
-
-  Future<Forecast> getForecastWeather(id, [String cityName, String unit]) async {
-    final localForecast = await box.get(id);
-    if (localForecast != null) {
-      print("localForecast");
-      return localForecast;
-    } else {
-      final remoteForecast = await this.client.fetchForecastWeather(
-            cityName: cityName,
-            unit: unit,
-          );
-      await this.box.put(id, remoteForecast);
-      print("remoteForecast");
-      return remoteForecast;
     }
   }
 }

--- a/weather_application/pubspec.yaml
+++ b/weather_application/pubspec.yaml
@@ -28,6 +28,9 @@ dependencies:
   hive: ^2.0.0
   hive_flutter: ^1.0.0
   path_provider: ^2.0.1
+  flutter_bloc: ^6.1.3
+  bloc: ^6.1.3
+  equatable: ^2.0.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
Weather bloc implemented.

Removed one method from the repository and updated the weather model to contain a list of weather items (Forecast) for a few reasons:

1. Having the repository with two methods that returns two different objects (Weather/ Forecast) means we need to cache separate objects even though they are both tightly related and can be handled as one object Weather.

2. It also means that my weather bloc needs to handle both fetch requests which again return different types. So I may be required to make a separate bloc and implement another bloc provider/ builder widget which is not necessary and includes adding alot of extra code. I could use Future.wait in my bloc and return a list of futures that are of a common type but again this seems messy and convoluted.

This implementation seemed to be better and lessens the amount of code in comparison to the other solutions.