### PR TITLE
onresume implementation

### DIFF
--- a/lib/screens/weather/weather_screen.dart
+++ b/lib/screens/weather/weather_screen.dart
@@ -1,6 +1,7 @@
 import 'package:hive/hive.dart';
 import 'package:weather_application/consts/consts.dart';
 import 'package:weather_application/models/weather_model.dart';
+import 'package:weather_application/utils/date_utils.dart';
 import 'package:weather_application/utils/enums.dart';
 import 'package:weather_application/widgets/annotated_scaffold.dart';
 import 'package:weather_application/widgets/themed_text.dart';
@@ -17,13 +18,37 @@ class WeatherScreen extends StatefulWidget {
   _WeatherScreenState createState() => _WeatherScreenState();
 }
 
-class _WeatherScreenState extends State<WeatherScreen> with SingleTickerProviderStateMixin {
+class _WeatherScreenState extends State<WeatherScreen> with SingleTickerProviderStateMixin, WidgetsBindingObserver {
   AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
 
   @override
   dispose() {
     _controller.dispose();
+    WidgetsBinding.instance.removeObserver(this);
     super.dispose();
+  }
+
+  @override
+  Future<void> didChangeAppLifecycleState(AppLifecycleState state) async {
+    super.didChangeAppLifecycleState(state);
+    switch (state) {
+      case AppLifecycleState.resumed:
+        Weather weather = Hive.box<Weather>(weatherBox).get(weatherBox);
+        String myCity = weather?.name ?? 'London';
+        if (MyDateUtils.timeDifference(weather.dt, 20)) {
+          BlocProvider.of<WeatherBloc>(context).add(
+            WeatherFetchedEvent(id: weatherBox, city: myCity, unit: 'Metric'),
+          );
+        }
+        break;
+      default:
+    }
   }
 
   @override

--- a/lib/utils/date_utils.dart
+++ b/lib/utils/date_utils.dart
@@ -24,4 +24,18 @@ class MyDateUtils {
       return '';
     }
   }
+
+  static bool timeDifference(int lastUpdated, int difference) {
+    var dateTimeWeather = DateTime.fromMillisecondsSinceEpoch(lastUpdated * 1000);
+    var dateTimeNow = DateTime.now();
+    print(dateTimeNow);
+    print(dateTimeWeather);
+
+    print(dateTimeNow.difference(dateTimeWeather).inMinutes);
+    if (dateTimeNow.difference(dateTimeWeather).inMinutes.abs() > difference) {
+      return true;
+    } else {
+      return false;
+    }
+  }
 }


### PR DESCRIPTION
AppLifeCycleState resume used to fetch weather after periods of inactivity from user.

If the app is backgrounded and then is resumed say after an hour inactivity the UI does not update as no fetch event is called. However, now if the user opens the weather app from background and the time between the last fetched weather and current time is greater then 20 minutes we refetch the weather.

The API recommends only making calls every 10 minutes, but for the resume method to work efficiently 10 minutes seemed too little. This is because if the time difference exceeds 10 minutes the app fetches the new weather, however i have noticed that after the 10 minute period it is common for the api to not have any new weather data so we are again fetching for no reason. It also meant the weather time is not updated and the app will try to fetch the weather every time the user opens the app until the new data is fetched from the server. 20 minutes is more then enough time to retrieve new data which consistently works and lets be honest a weather app is not going to be opened every 10 minutes, its likely to be open once or twice a day,