### PR TITLE
Fixed first location caching issue

### DIFF
--- a/lib/blocs/search/search_bloc.dart
+++ b/lib/blocs/search/search_bloc.dart
@@ -11,18 +11,8 @@ part 'search_state.dart';
 
 class SearchBloc extends Bloc<SearchEvent, SearchState> {
   final SearchRepository repository;
-  final WeatherBloc weatherBloc;
-  StreamSubscription subscription;
 
-  SearchBloc({@required this.repository, this.weatherBloc}) : super(SearchInitial()) {
-    if (weatherBloc != null) {
-      subscription = weatherBloc.stream.listen((state) {
-        if (state is WeatherLoadSuccess) {
-          add(SearchAddedEvent(city: state.city, country: state.weather.country));
-        }
-      });
-    }
-  }
+  SearchBloc({@required this.repository}) : super(SearchInitial());
 
   @override
   Stream<SearchState> mapEventToState(
@@ -75,11 +65,5 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
     } catch (e) {
       yield SearchUpdatedFailedState();
     }
-  }
-
-  @override
-  Future<void> close() {
-    subscription.cancel();
-    return super.close();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -97,8 +97,7 @@ void main() async {
             repository: SearchRepository(
               box: HiveRepository(searchBox),
             ),
-            weatherBloc: BlocProvider.of<WeatherBloc>(context),
-          )..add(SearchFetchedEvent()),
+          ),
         ),
       ],
       child: MyApp(),

--- a/lib/repositories/search_repository.dart
+++ b/lib/repositories/search_repository.dart
@@ -1,5 +1,3 @@
-import 'dart:collection';
-
 import 'package:weather_application/interfaces/i_repository.dart';
 import 'package:weather_application/models/search_model.dart';
 

--- a/lib/screens/weather/weather_screen.dart
+++ b/lib/screens/weather/weather_screen.dart
@@ -1,4 +1,5 @@
 import 'package:hive/hive.dart';
+import 'package:weather_application/blocs/search/search_bloc.dart';
 import 'package:weather_application/blocs/settings/settings_bloc.dart';
 import 'package:weather_application/consts/consts.dart';
 import 'package:weather_application/consts/screen_consts.dart';
@@ -57,7 +58,17 @@ class _WeatherScreenState extends State<WeatherScreen> with TickerProviderStateM
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<WeatherBloc, WeatherState>(
+    return BlocConsumer<WeatherBloc, WeatherState>(
+      listener: (context, state) {
+        if (state is WeatherLoadSuccess) {
+          BlocProvider.of<SearchBloc>(context).add(
+            SearchAddedEvent(
+              city: state.weather.name,
+              country: state.weather.country,
+            ),
+          );
+        }
+      },
       builder: (context, state) {
         String myCity;
         if (state is WeatherLoadSuccess) {


### PR DESCRIPTION
Replaced bloc builder with bloc consumer which fires search add event on weather fetch success state. Removed stream subscription as it is no longer necessary due to listener. The bug is that streamsubscription was not firing on first launch due to the location of the blocbuilder of type SearchBloc. So either I needed to add blocbuilder of type searchbloc to the widget tree, or add a bloclistener and remove the subscription. the latter seemed more concise.